### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -320,6 +320,6 @@ from docutils.utils import get_source_line
 
 def _supress_nonlocal_image_warn(self, msg, node, **kwargs):
     if not msg.startswith('nonlocal image URI found:'):
-        self._warnfunc(msg, '%s:%s' % get_source_line(node), **kwargs)
+        self._warnfunc(msg, '{0!s}:{1!s}'.format(*get_source_line(node)), **kwargs)
 
 sphinx.environment.BuildEnvironment.warn_node = _supress_nonlocal_image_warn


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:3ptscience:steno3dpy?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:3ptscience:steno3dpy?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
